### PR TITLE
Fixed issue on custom type with options

### DIFF
--- a/lib/active_model_attributes.rb
+++ b/lib/active_model_attributes.rb
@@ -12,6 +12,7 @@ module ActiveModelAttributes
 
   module ClassMethods
     NO_DEFAULT_PROVIDED = Object.new
+    SERVICE_ATTRIBUTES = %i(default user_provided_default).freeze
     private_constant :NO_DEFAULT_PROVIDED
 
     def attribute(name, cast_type, **options)
@@ -32,7 +33,7 @@ module ActiveModelAttributes
 
     def define_attribute_writer(name, cast_type, options)
       define_method "#{name}=" do |val|
-        deserialized_value = ActiveModel::Type.lookup(cast_type, **options).cast(val)
+        deserialized_value = ActiveModel::Type.lookup(cast_type, **options.except(*SERVICE_ATTRIBUTES)).cast(val)
         instance_variable_set("@#{name}", deserialized_value)
       end
     end

--- a/lib/active_model_attributes.rb
+++ b/lib/active_model_attributes.rb
@@ -32,7 +32,7 @@ module ActiveModelAttributes
 
     def define_attribute_writer(name, cast_type, options)
       define_method "#{name}=" do |val|
-        deserialized_value = ActiveModel::Type.lookup(cast_type).cast(val)
+        deserialized_value = ActiveModel::Type.lookup(cast_type, **options).cast(val)
         instance_variable_set("@#{name}", deserialized_value)
       end
     end


### PR DESCRIPTION
Had an issue defining a custom type with options:
```
attribute :field, :some_type, some_option: 'some value'
```
The value had not been passed to the type.