### PR TITLE
Allow untyped attributes (as Rails does)

### DIFF
--- a/lib/active_model_attributes.rb
+++ b/lib/active_model_attributes.rb
@@ -15,7 +15,7 @@ module ActiveModelAttributes
     SERVICE_ATTRIBUTES = %i(default user_provided_default).freeze
     private_constant :NO_DEFAULT_PROVIDED
 
-    def attribute(name, cast_type, **options)
+    def attribute(name, cast_type = ActiveModel::Type::Value.new, **options)
       self.attributes_registry = attributes_registry.merge(name => [cast_type, options])
 
       define_attribute_reader(name, options)
@@ -37,7 +37,10 @@ module ActiveModelAttributes
     def define_attribute_writer(name, cast_type, options)
       wrapper = Module.new do
         define_method "#{name}=" do |val|
-          deserialized_value = ActiveModel::Type.lookup(cast_type, **options.except(*SERVICE_ATTRIBUTES)).cast(val)
+          if cast_type.is_a?(Symbol)
+            cast_type = ActiveModel::Type.lookup(cast_type, **options.except(*SERVICE_ATTRIBUTES))
+          end
+          deserialized_value = cast_type.cast(val)
           instance_variable_set("@#{name}", deserialized_value)
         end
       end

--- a/spec/active_model_attributes_spec.rb
+++ b/spec/active_model_attributes_spec.rb
@@ -95,6 +95,21 @@ describe ActiveModelAttributes do
     end
   end
 
+  class ModelForAttributesTestWithDefaultType
+    include ActiveModel::Model
+    include ActiveModelAttributes
+
+    attribute :value
+    attribute :other_value, default: 'foo'
+  end
+
+  it "handles attributes assignment with default type and with a default value" do
+    data = ModelForAttributesTestWithDefaultType.new(value: { foo: 'bar' })
+
+    expect(data.value).to eq(foo: 'bar')
+    expect(data.other_value).to eq 'foo'
+  end
+
   it "handles attributes assignment with proper type and with proper defaults" do
     data = ModelForAttributesTest.new(
       integer_field: "2.3",


### PR DESCRIPTION
Allow untyped attributes by defaulting to the `ActiveModel::Type::Value` type.

Rails 5.2 will support typed attributes on ActiveModel, however their
implementation supports untyped attributes as well.

This change means that the gem is compatible with the upcoming change in Rails.