### PR TITLE
Removed text data type that is no longer supported since 2016 Dec

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Here's a list of supported types:
 * immutable_string
 * integer
 * string
-* text
 * time
 
 You can also add your custom types. Just create a class inheriting from `ActiveModel::Type::Value` or already existing type, e.g. `ActiveModel::Type::Integer`, define `cast` method and register the new type:


### PR DESCRIPTION
Removed text data type that is no longer supported since [2016 Dec](https://github.com/rails/rails/commit/ef76f83f4cf0f27e84c0c5f4a3ff426d7ad84d9d\#diff-deee7dd500c72b8dcf74be5f6a633376)