### PR TITLE
Add `attribute_types` method to match behaviour that Rails 6 ActiveModel::Attributes provides

### DIFF
--- a/active_model_attributes.gemspec
+++ b/active_model_attributes.gemspec
@@ -25,7 +25,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "pry-byebug"
+  if RUBY_VERSION >= "2.4"
+    spec.add_development_dependency "pry-byebug"
+  end
   spec.add_development_dependency "coveralls"
 
   spec.add_dependency "activemodel", ">= 5.0"

--- a/active_model_attributes.gemspec
+++ b/active_model_attributes.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.1.2"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"

--- a/lib/active_model_attributes.rb
+++ b/lib/active_model_attributes.rb
@@ -8,8 +8,9 @@ module ActiveModelAttributes
   delegate :type_for_attribute, :has_attribute?, to: :class
 
   included do
-    class_attribute :attributes_registry, instance_accessor: false
+    class_attribute :attributes_registry, :attribute_types, instance_accessor: false
     self.attributes_registry = {}
+    self.attribute_types = Hash.new(ActiveModel::Type.default_value)
   end
 
   module ClassMethods
@@ -22,6 +23,11 @@ module ActiveModelAttributes
 
       define_attribute_reader(name, options)
       define_attribute_writer(name, cast_type, options)
+
+      if cast_type.is_a?(Symbol)
+        cast_type = ActiveModel::Type.lookup(cast_type, **options.except(:default))
+      end
+      self.attribute_types = attribute_types.merge(name.to_s => cast_type)
     end
 
     def define_attribute_reader(name, options)

--- a/spec/active_model_attributes_spec.rb
+++ b/spec/active_model_attributes_spec.rb
@@ -220,6 +220,15 @@ describe ActiveModelAttributes do
     expect(data.has_attribute?(:nonexisting_field)).to eq false
   end
 
+  describe ".attribute_types" do
+    it "returns a hash of attribute names with their type information" do
+      expect(ModelForAttributesTest.attribute_types['integer_field']).to be_an_instance_of ActiveModel::Type::Integer
+      expect(ModelForAttributesTest.attribute_types['string_field']).to be_an_instance_of ActiveModel::Type::String
+      expect(ModelForAttributesTest.attribute_types['decimal_field']).to be_an_instance_of ActiveModel::Type::Decimal
+      expect(ModelForAttributesTest.attribute_types['boolean_with_type']).to be_an_instance_of ActiveModel::Type::Boolean
+    end
+  end
+
   it "returns type information for available attributes" do
     data = ModelForAttributesTest.new
 
@@ -228,6 +237,7 @@ describe ActiveModelAttributes do
     expect(data.type_for_attribute(:decimal_field)).to be_an_instance_of ActiveModel::Type::Decimal
     expect(data.type_for_attribute(:boolean_with_type)).to be_an_instance_of ActiveModel::Type::Boolean
   end
+
   it "returns type information with options for available attributes" do
     data = ModelForAttributesTestWithCustomTypeWithOptions.new
 


### PR DESCRIPTION
The shoulda-matchers gem [looks for the `attribute_types` method on a
model class](https://github.com/thoughtbot/shoulda-matchers/blob/v4.3.0/lib/shoulda/matchers/rails_shim.rb#L141-L163), and by providing it we can avoid [errors](https://github.com/thoughtbot/shoulda-matchers/issues/1288) caused by
ActiveModelAttributes classes implementing some of the ActiveRecord spec
(e.g. implementing `type_for_attribute` but not implementing `columns`).